### PR TITLE
Allow to configure endpoint to support third-party s3 compatible storage (e.g. Wasabi)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,7 @@ parquet:
     S3:
         # If NULL boto will default to using ENV vars or credentials file
         # prefix: a prefix to append to the default data path
+        endpoint: null
         key_id: null
         secret: null
         bucket: null

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -43,7 +43,7 @@ class Parquet(Store):
                 self._list.append(aws_list)
                 self.bucket.append(config['S3']['bucket'])
                 self.prefix.append(config['S3']['prefix'])
-                self.kwargs.append({'creds': (config['S3']['key_id'], config['S3']['secret'])})
+                self.kwargs.append({'creds': (config['S3']['key_id'], config['S3']['secret']), 'endpoint': config['S3'].get('endpoint')})
 
     def aggregate(self, data):
         names = list(data[0].keys())

--- a/cryptostore/data/s3.py
+++ b/cryptostore/data/s3.py
@@ -7,10 +7,11 @@ associated with this software.
 from cryptostore.engines import StorageEngines
 
 
-def aws_write(bucket, key, data, creds=(None, None)):
+def aws_write(bucket, key, data, creds=(None, None), endpoint=None):
     client = StorageEngines.boto3.client('s3',
         aws_access_key_id=creds[0],
-        aws_secret_access_key=creds[1]
+        aws_secret_access_key=creds[1],
+        endpoint_url=endpoint
     )
 
     with open(data, 'rb') as fp:


### PR DESCRIPTION
I have tested this change with
```endpoint: https://s3.eu-central-1.wasabisys.com```
