### PR TITLE
Fix the unclear parquet name in S3.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,20 @@ exchanges:
             book_interval: 100000
         trades: [BTC-USD, ETH-USD, ETH-BTC]
         ticker: [BTC-USD]
+    OKEX:
+        retries: -1
+        l2_book_swap:
+            symbols: [BTC-USD-SWAP]
+            book_delta: true
+            book_interval: 100
+        trades_swap: [BTC-USD-SWAP]
+        ticker_swap: [BTC-USD-SWAP]
+        l2_book_futures:
+            symbols: [BTC-USD-200626]
+            book_delta: true
+            book_interval: 100
+        trades_futures: [BTC-USD-200626]
+        ticker_futures: [BTC-USD-200626]
 
 # Where to store the data. Currently arctic, influx, elastic, and parquet are supported. More than one can be enabled
 storage: [arctic, influx]

--- a/cryptostore/aggregator/kafka.py
+++ b/cryptostore/aggregator/kafka.py
@@ -7,7 +7,7 @@ associated with this software.
 import json
 import logging
 
-from cryptofeed.defines import L2_BOOK, L3_BOOK, TRADES, TICKER, FUNDING, OPEN_INTEREST
+from cryptofeed.defines import L2_BOOK, L3_BOOK, TRADES, TICKER, FUNDING, OPEN_INTEREST, TRADES_SWAP, L2_BOOK_SWAP, TICKER_SWAP, TRADES_FUTURES, L2_BOOK_FUTURES, TICKER_FUTURES
 
 from cryptostore.engines import StorageEngines
 from cryptostore.aggregator.cache import Cache
@@ -56,10 +56,10 @@ class Kafka(Cache):
             self.ids[key] = message
             update = json.loads(message.value().decode('utf8'))
 
-            if dtype in {L2_BOOK, L3_BOOK}:
+            if dtype in {L2_BOOK, L3_BOOK, L2_BOOK_FUTURES, L2_BOOK_SWAP}:
                 update = book_flatten(update, update['timestamp'], update['delta'])
                 ret.extend(update)
-            if dtype in {TRADES, TICKER, FUNDING, OPEN_INTEREST}:
+            if dtype in {TRADES, TRADES_FUTURES, TRADES_SWAP, TICKER, TICKER_FUTURES, TICKER_SWAP, FUNDING, OPEN_INTEREST}:
                 ret.append(update)
         return ret
 

--- a/cryptostore/aggregator/redis.py
+++ b/cryptostore/aggregator/redis.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import json
 import time
 
-from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, TICKER, FUNDING, OPEN_INTEREST
+from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, TICKER, FUNDING, OPEN_INTEREST, TRADES_SWAP, L2_BOOK_SWAP, TICKER_SWAP, TRADES_FUTURES, L2_BOOK_FUTURES, TICKER_FUTURES
 
 from cryptostore.aggregator.util import book_flatten
 from cryptostore.aggregator.cache import Cache
@@ -46,7 +46,7 @@ class Redis(Cache):
         ret = []
 
         for update_id, update in data[0][1]:
-            if dtype in {L2_BOOK, L3_BOOK}:
+            if dtype in {L2_BOOK, L3_BOOK, L2_BOOK_FUTURES, L2_BOOK_SWAP}:
                 update = json.loads(update['data'])
                 update = book_flatten(update, update['timestamp'], update['receipt_timestamp'], update['delta'])
                 for u in update:
@@ -54,7 +54,7 @@ class Redis(Cache):
                         if k in u:
                             u[k] = float(u[k])
                 ret.extend(update)
-            elif dtype in {TRADES, TICKER, OPEN_INTEREST}:
+            elif dtype in {TRADES, TRADES_FUTURES, TRADES_SWAP, TICKER, TICKER_FUTURES, TICKER_SWAP, OPEN_INTEREST}:
                 for k in ('size', 'amount', 'price', 'timestamp', 'receipt_timestamp', 'bid', 'ask', 'open_interest'):
                     if k in update:
                         update[k] = float(update[k])
@@ -63,8 +63,7 @@ class Redis(Cache):
                 for k in update:
                     try:
                         update[k] = float(update[k])
-                    except ValueError:
-                        # ignore strings
+                    except:
                         pass
                 ret.append(update)
             self.ids[key].append(update_id)

--- a/cryptostore/collector.py
+++ b/cryptostore/collector.py
@@ -72,19 +72,19 @@ class Collector(Process):
                 kwargs = {'host': self.config['kafka']['ip'], 'port': self.config['kafka']['port']}
 
             if callback_type == TRADES:
-                cb[TRADES] = [trade_cb(**kwargs)]
+                cb[TRADES] = [trade_cb(key=TRADES, **kwargs)]
             elif callback_type == TRADES_SWAP:
-                cb[TRADES_SWAP] = [trade_cb(**kwargs)]
+                cb[TRADES_SWAP] = [trade_cb(key=TRADES_SWAP, **kwargs)]
             elif callback_type == TRADES_FUTURES:
-                cb[TRADES_FUTURES] = [trade_cb(**kwargs)]
+                cb[TRADES_FUTURES] = [trade_cb(key=TRADES_FUTURES, **kwargs)]
             elif callback_type == FUNDING:
                 cb[FUNDING] = [funding_cb(**kwargs)]
             elif callback_type == TICKER:
-                cb[TICKER] = [ticker_cb(**kwargs)]
+                cb[TICKER] = [ticker_cb(key=TICKER, **kwargs)]
             elif callback_type == TICKER_SWAP:
-                cb[TICKER_SWAP] = [ticker_cb(**kwargs)]
+                cb[TICKER_SWAP] = [ticker_cb(key=TICKER_SWAP, **kwargs)]
             elif callback_type == TICKER_FUTURES:
-                cb[TICKER_FUTURES] = [ticker_cb(**kwargs)]
+                cb[TICKER_FUTURES] = [ticker_cb(key=TICKER_FUTURES, **kwargs)]
             elif callback_type == L2_BOOK:
                 cb[L2_BOOK] = [book_cb(key=L2_BOOK, **kwargs)]
                 if book_up:

--- a/cryptostore/collector.py
+++ b/cryptostore/collector.py
@@ -9,7 +9,7 @@ from multiprocessing import Process
 import logging
 
 from cryptofeed import FeedHandler
-from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, BOOK_DELTA, TICKER, FUNDING, OPEN_INTEREST
+from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, BOOK_DELTA, TICKER, FUNDING, OPEN_INTEREST, TRADES_SWAP, L2_BOOK_SWAP, TICKER_SWAP, TRADES_FUTURES, L2_BOOK_FUTURES, TICKER_FUTURES
 
 
 LOG = logging.getLogger('cryptostore')
@@ -46,7 +46,7 @@ class Collector(Process):
             if 'max_depth' in value:
                 depth = value['max_depth']
 
-            if callback_type in (L2_BOOK, L3_BOOK):
+            if callback_type in (L2_BOOK, L3_BOOK, L2_BOOK_SWAP, L2_BOOK_FUTURES):
                 self.exchange_config[callback_type] = self.exchange_config[callback_type]['symbols']
 
             if cache == 'redis':
@@ -73,14 +73,30 @@ class Collector(Process):
 
             if callback_type == TRADES:
                 cb[TRADES] = [trade_cb(**kwargs)]
+            elif callback_type == TRADES_SWAP:
+                cb[TRADES_SWAP] = [trade_cb(**kwargs)]
+            elif callback_type == TRADES_FUTURES:
+                cb[TRADES_FUTURES] = [trade_cb(**kwargs)]
             elif callback_type == FUNDING:
                 cb[FUNDING] = [funding_cb(**kwargs)]
             elif callback_type == TICKER:
                 cb[TICKER] = [ticker_cb(**kwargs)]
+            elif callback_type == TICKER_SWAP:
+                cb[TICKER_SWAP] = [ticker_cb(**kwargs)]
+            elif callback_type == TICKER_FUTURES:
+                cb[TICKER_FUTURES] = [ticker_cb(**kwargs)]
             elif callback_type == L2_BOOK:
                 cb[L2_BOOK] = [book_cb(key=L2_BOOK, **kwargs)]
                 if book_up:
                     cb[BOOK_DELTA] = [book_up(key=L2_BOOK, **kwargs)]
+            elif callback_type == L2_BOOK_SWAP:
+                cb[L2_BOOK_SWAP] = [book_cb(key=L2_BOOK_SWAP, **kwargs)]
+                if book_up:
+                    cb[BOOK_DELTA] = [book_up(key=L2_BOOK_SWAP, **kwargs)]
+            elif callback_type == L2_BOOK_FUTURES:
+                cb[L2_BOOK_FUTURES] = [book_cb(key=L2_BOOK_FUTURES, **kwargs)]
+                if book_up:
+                    cb[BOOK_DELTA] = [book_up(key=L2_BOOK_FUTURES, **kwargs)]
             elif callback_type == L3_BOOK:
                 cb[L3_BOOK] = [book_cb(key=L3_BOOK, **kwargs)]
                 if book_up:
@@ -97,10 +113,18 @@ class Collector(Process):
 
                     if callback_type == TRADES:
                         cb[TRADES].append(TradeZMQ(host=host, port=port))
+                    elif callback_type == TRADES_SWAP:
+                        cb[TRADES_SWAP].append(TradeZMQ(host=host, port=port))
+                    elif callback_type == TRADES_FUTURES:
+                        cb[TRADES_FUTURES].append(TradeZMQ(host=host, port=port))
                     elif callback_type == FUNDING:
                         cb[FUNDING].append(FundingZMQ(host=host, port=port))
                     elif callback_type == L2_BOOK:
                         cb[L2_BOOK].append(BookZMQ(host=host, port=port))
+                    elif callback_type == L2_BOOK_SWAP:
+                        cb[L2_BOOK_SWAP].append(BookZMQ(host=host, port=port))
+                    elif callback_type == L2_BOOK_FUTURES:
+                        cb[L2_BOOK_FUTURES].append(BookZMQ(host=host, port=port))
                     elif callback_type == L3_BOOK:
                         cb[L3_BOOK].append(BookZMQ(host=host, port=port))
                     elif callback_type == OPEN_INTEREST:

--- a/cryptostore/data/influx.py
+++ b/cryptostore/data/influx.py
@@ -7,7 +7,7 @@ associated with this software.
 from decimal import Decimal
 from collections import defaultdict
 
-from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, TICKER, FUNDING, OPEN_INTEREST
+from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, TICKER, FUNDING, OPEN_INTEREST, TRADES_SWAP, L2_BOOK_SWAP, TICKER_SWAP, TRADES_FUTURES, L2_BOOK_FUTURES, TICKER_FUTURES
 import requests
 
 from cryptostore.data.store import Store
@@ -37,7 +37,7 @@ class InfluxDB(Store):
         # influx cant handle duplicate data (?!) so we need to
         # incremement timestamps on data that have the same timestamp
         used_ts = set()
-        if data_type == TRADES:
+        if data_type in (TRADES, TRADES_SWAP, TRADES_FUTURES):
             for entry in self.data:
                 ts = int(Decimal(entry["timestamp"]) * 1000000000)
                 while ts in used_ts:
@@ -47,12 +47,12 @@ class InfluxDB(Store):
                     agg.append(f'{data_type}-{exchange},pair={pair},exchange={exchange} side="{entry["side"]}",id="{entry["id"]}",amount={entry["amount"]},price={entry["price"]},timestamp={entry["timestamp"]},receipt_timestamp={entry["receipt_timestamp"]} {ts}')
                 else:
                     agg.append(f'{data_type}-{exchange},pair={pair},exchange={exchange} side="{entry["side"]}",amount={entry["amount"]},price={entry["price"]},timestamp={entry["timestamp"]},receipt_timestamp={entry["receipt_timestamp"]} {ts}')
-        elif data_type == TICKER:
+        elif data_type in (TICKER, TICKER_SWAP, TICKER_FUTURES):
             for entry in self.data:
                 ts = int(Decimal(entry["timestamp"]) * 1000000000)
                 agg.append(f'{data_type}-{exchange},pair={pair},exchange={exchange} bid={entry["bid"]},ask={entry["ask"]},timestamp={entry["timestamp"]},receipt_timestamp={entry["receipt_timestamp"]} {ts}')
 
-        elif data_type == L2_BOOK:
+        elif data_type in (L2_BOOK, L2_BOOK_SWAP, L2_BOOK_FUTURES):
             for entry in self.data:
                 ts = int(Decimal(entry["timestamp"]) * 1000000000)
                 while ts in used_ts:

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -66,7 +66,7 @@ class Parquet(Store):
 
         if self._write:
             for func, bucket, prefix, kwargs in zip(self._write, self.bucket, self.prefix, self.kwargs):
-                path = f'{exchange}/{data_type}/{pair}/{int(timestamp)}.parquet'
+                path = f'{exchange}/{data_type}/{pair}/{exchange}-{data_type}-{pair}-{int(timestamp)}.parquet'
                 if prefix:
                     path = f"{prefix}/{path}"
                 func(bucket, path, file_name, **kwargs)


### PR DESCRIPTION
<img width="484" alt="Screen Shot 2020-04-15 at 14 38 14" src="https://user-images.githubusercontent.com/22584737/79305912-cfcc9f00-7f26-11ea-8808-2e589d0bda30.png">

when you load files from S3 using AWS UI, you get a list of these into **you local PC**, with a file name like '14534534636.parquet' you do not know which coin, which exchange of each file belongs to.