### PR TITLE
Refactoring Google Drive connector to reduce http connection overhead.

### DIFF
--- a/cryptostore/aggregator/aggregator.py
+++ b/cryptostore/aggregator/aggregator.py
@@ -79,13 +79,13 @@ class Aggregator(Process):
                         interval_start = end + timedelta(seconds=interval + 1)
                     start, end = get_time_interval(interval_start, base_interval, multiplier=multiplier)
                 if 'exchanges' in self.config and self.config.exchanges:
+                    store = Storage(self.config)
                     for exchange in self.config.exchanges:
                         for dtype in self.config.exchanges[exchange]:
                             # Skip over the retries arg in the config if present.
                             if dtype in {'retries', 'channel_timeouts'}:
                                 continue
                             for pair in self.config.exchanges[exchange][dtype] if 'symbols' not in self.config.exchanges[exchange][dtype] else self.config.exchanges[exchange][dtype]['symbols']:
-                                store = Storage(self.config)
                                 LOG.info('Reading %s-%s-%s', exchange, dtype, pair)
                                 data = cache.read(exchange, dtype, pair, start=start, end=end)
                                 if len(data) == 0:

--- a/cryptostore/data/gd.py
+++ b/cryptostore/data/gd.py
@@ -156,5 +156,3 @@ accessible folder.".format(prefix))
         response = None
         while response is None:
             status, response = request.next_chunk(num_retries=4, http=auth_http)
-
-        return

--- a/cryptostore/data/gd.py
+++ b/cryptostore/data/gd.py
@@ -7,147 +7,156 @@ associated with this software.
 # Removed as not used
 # from cryptostore.engines import StorageEngines
 
-from typing import Tuple
+from typing import Tuple, Callable
+import httplib2
 import google.auth
 from google.oauth2 import service_account
 import googleapiclient.discovery as gad
 import googleapiclient.http as gah
+from googleapiclient import _auth
 from cryptostore.exceptions import InconsistentStorage
 
 
-def _get_drive(creds: str = None) -> gad.Resource:
-    """
-    Return `drive` service with required credentials and required scope to
-    perform list/read/write operations in Google Drive.
+class GDriveConnector:
 
-    Parameters
-        creds (str):
-            Path to credential file.
+    cache_path = '.cache'
 
-    Returns
-        drive (gad.Resource):
-            google Drive service loaded with 'scoped' credentials.
+    def __init__(self, creds: str, exchanges: dict, prefix: str,
+                 path: Callable[[str, str, str], str]):
+        """
+        Initialize a `drive` service, and create the list of folders' IDs,
+        either retrieving them if already existing, or creating them if not
+        existing.
 
-    """
+        Parameters:
+            creds (str):
+                Path to credential file.
+            exchanges (dict):
+                List of exchanges with related data types and pairs that are
+                retrieved by cryptostore.
+            prefix (str):
+                Base folder into which storing recorded data.
+            path (Callable[[str, str, str], str]):
+                Function from which deriving folders' name.
 
-    if creds:
-        creds = service_account.Credentials.from_service_account_file(creds).with_scopes(['https://www.googleapis.com/auth/drive'])
-    else:
-        # use environment variable GOOGLE_APPLICATION_CREDENTIALS
-        creds, project = google.auth.default(scopes=['https://www.googleapis.com/auth/drive'])
+        """
 
-    return gad.build('drive', 'v3', credentials=creds)
+        # Initialize a drive service, with an authorized caching-enabled
+        # `http` object.
+        if creds:
+            self.creds = service_account.Credentials.from_service_account_file(creds)\
+                                        .with_scopes(['https://www.googleapis.com/auth/drive'])
+        else:
+            # Use environment variable GOOGLE_APPLICATION_CREDENTIALS
+            self.creds, project = google.auth.default(scopes=['https://www.googleapis.com/auth/drive'])
+        auth_http = _auth.authorized_http(self.creds)
+        auth_http.cache = httplib2.FileCache(self.cache_path)
+        self.drive = gad.build('drive', 'v3', http=auth_http)
 
+        files = self.drive.files()
+        # Retrieve candidates for child and parent folders in Google Drive.
+        # `pageSize` is by default to 100 and is limited to 1000.
+        # Use of `list_next()` appears buggy, using `nextPageToken` instead.
+        # https://github.com/googleapis/google-api-python-client/issues/989
+        g_drive_folders = []
+        page_token = None
+        while True:
+            res = files.list(q="mimeType = 'application/vnd.google-apps.folder' and trashed = false",
+                             pageSize=800, pageToken=page_token,
+                             fields='nextPageToken, files(id, name, parents)')\
+                       .execute()
+            g_drive_folders.extend(res.get('files', []))
+            page_token = res.get('nextPageToken', None)
+            if page_token is None:
+                break
 
-def _get_folder_in_parent(drive: gad.Resource, path: str) -> Tuple[str, str]:
-    """
-    Retrieve folder ID from given name and parent folder name.
-    If not existing, it is created.
-
-    Parameters:
-        drive (gad.Resource):
-            Service with which interacting with Google Drive.
-        path (str):
-            path = '{prefix}/{exchange}/{data_type}/{pair}/
-                        {exchange}-{data_type}-{pair}-{int(timestamp)}.parquet'
-            String from which is retrieved `prefix` (parent folder) and name of
-            child folder '{exchange}-{data_type}-{pair}'.
-
-    Returns:
-        folder_id, folder_name (Tuple[str, str]):
-            Id of child folder '{exchange}-{data_type}-{pair}'. Create it if
-            not existing.
-
-    """
-
-    # Retrieve parent folder (prefix), and child folder.
-    path_struct = path.split('/')
-    folder_name = '-'.join(path_struct[1:4])
-    if len(path_struct) > 5:
-        # If larger than 5, it means prefix is more than a single folder.
-        # This case is not supported.
-        raise InconsistentStorage("Prefix {!s} appears to be a path. Only a single folder name is accepted.".format(folder_name))
-
-    parent_name = path_struct[0]
-    # Retrieve candidates for child and parent folders.
-    res = drive.files().list(q="(name = '" + parent_name + "' or name = '"
-                                           + folder_name + "') and mimeType = 'application/vnd.google-apps.folder' and trashed = false",
-                             pageSize=20,
-                             fields='files(id, name, parents)').execute()
-    folders = res.get('files', [])
-
-    # Manage parent folder.
-    p_folders = [(folder['id'], folder['name']) for folder in folders
-                 if folder['name'] == parent_name]
-    if len(p_folders) > 1:
-        # If more than 2 folders with the same name, throw an error. We do not
-        # know which one is the right one to record data.
-        raise InconsistentStorage("At least 2 parent folders identified with \
+        # Retrieve parent folder ID (prefix).
+        p_folders = [folder['id'] for folder in g_drive_folders if folder['name'] == prefix]
+        if len(p_folders) > 1:
+            # If more than 2 folders with the same name, throw an error. We do not
+            # know which one is the right one to record data.
+            raise InconsistentStorage("At least 2 parent folders identified with \
 name {!s}. Please, make sure to provide a prefix corresponding to a unique \
-folder name in your Google Drive space.".format(parent_name))
-    elif not p_folders:
-        # If parent folder is not found, ask the user to create one.
-        raise InconsistentStorage("No existing folder found with name {!s}. \
+folder name in your Google Drive space.".format(prefix))
+        elif not p_folders:
+            # If parent folder is not found, ask the user to create one.
+            raise InconsistentStorage("No existing folder found with name {!s}. \
 Please, make sure to provide a prefix corresponding to an existing and \
-accessible folder.".format(parent_name))
-    else:
-        p_folder_id = p_folders[0][0]
+accessible folder.".format(prefix))
+        else:
+            p_folder_id = p_folders[0]
 
-    # Manage child folder.
-    c_folders = [(folder['id'], folder['name']) for folder in folders
-                 if ((folder['name'] == folder_name) and ('parents' in folder)
-                     and (p_folder_id in folder['parents']))]
-    if len(c_folders) > 1:
-        # If more than 2 folders with the same name, throw an error. We do not
-        # know which one is the right one to record data.
-        raise InconsistentStorage("At least 2 folders identified with name {!s}. Please, clean content of parent folder.".format(folder_name))
-    elif not c_folders:
-        # If folder not found, create it.
-        folder_metadata = {'name': folder_name,
-                           'mimeType': 'application/vnd.google-apps.folder',
-                           'parents': [p_folder_id]}
-        folder = drive.files().create(body=folder_metadata, fields='id')\
-                              .execute()
+        # Manage child folders. Build list of folders' name.
+        c_folders = []
+        for exchange in exchanges:
+            for dtype in exchanges[exchange]:
+                # Skip over the retries arg in the config if present.
+                if dtype in {'retries', 'channel_timeouts'}:
+                    continue
+                for pair in exchanges[exchange][dtype] if 'symbols' not in exchanges[exchange][dtype] else exchanges[exchange][dtype]['symbols']:
+                    c_folders.append('-'.join(path(exchange, dtype, pair).split('/')))
+        # Retrieve ID for existing ones.
+        existing_childs = [(folder['name'], folder['id']) for folder in g_drive_folders
+                           if ((folder['name'] in c_folders) and ('parents' in folder)
+                           and (p_folder_id in folder['parents']))]
+        # If duplicates in folder names, throw an exception.
+        existing_as_dict = dict(existing_childs)
+        n = len(existing_childs) - len(existing_as_dict)
+        if n != 0:
+            raise InconsistentStorage("{!s} existing folder(s) share(s) same name with another. Please, clean content of {!s} folder.".format(n, prefix))
+        # Get missing ones and create corresponding child folders in batch.
+        missing_childs = list(set(c_folders) - set(existing_as_dict))
+        # Number of calls in batch is limited to 1000.
+        call_limit = 800
+        missing_in_chunks = [missing_childs[x:x+call_limit] for x in range(0, len(missing_childs), call_limit)]
+        # Setup & operate requests in batch.
+        def _callback(request_id, response, exception, keep=existing_as_dict):
+            keep[response['name']] = response['id']
+            return
+        for sub_list in missing_in_chunks:
+            batch = self.drive.new_batch_http_request(_callback)
+            for folder in sub_list:
+                folder_metadata = {'name': folder,
+                                   'mimeType': 'application/vnd.google-apps.folder',
+                                   'parents': [p_folder_id]}
+                batch.add(files.create(body=folder_metadata, fields='id, name'))
+            batch.execute()
+        self.folders = existing_as_dict
 
-        return folder.get('id'), folder_name
-    else:
-        # Single folder found.
 
-        return folders[0]['id'], folder_name
+    def write(self, bucket: str, path: str, file_name: str, **kwargs):
+        """
+        Upload file to Google Drive. File is stored in a parent folder which
+        name is that of 'path', replacing '/' with '-'. Folder name is
+        generated in `__init__`.
 
-
-def google_drive_write(bucket: str, path: str, file_name: str, creds: str):
-    """
-    Upload file to Google Drive.
-    File is stored in a parent folder which name is that of 'path' without the
-    '/'.
-
-    Parameters
-        bucket:
-            Unused parameter.
-        path (str):
-            path = '{prefix}/{exchange}/{data_type}/{pair}/
+        Parameters:
+            bucket:
+                Unused parameter.
+            path (str):
+                path = '{exchange}/{data_type}/{pair}/
                         {exchange}-{data_type}-{pair}-{int(timestamp)}.parquet'
-            String from which is derived folder name into which is written the
-            file, as well as the root folder that will contain all these
-            folders.
-        file_name (str):
-            File name preceded by path on local disk.
-        creds (str):
-            Path to credential file.
+                String from which is derived folder name into which is written
+                the file.
+            file_name (str):
+                File name preceded by path on local disk.
 
-    """
+        """
 
-    # Retrieve folder ID to be used to write the file into, and upload.
-    # If not existing, folder will be created.
-    drive = _get_drive(creds)
-    folder_id, folder_name = _get_folder_in_parent(drive, path)
-    media = gah.MediaFileUpload(file_name, resumable=True)
-    file_metadata = {'name': path.split('/')[-1], 'parents': [folder_id]}
-    request = drive.files().create(body=file_metadata, media_body=media,
-                                   fields='id')
-    response = None
-    while response is None:
-        status, response = request.next_chunk(num_retries=4)
+        # Retrieve folder ID to be used to write the file into.
+        # Get folder name first.
+        folder_name = '-'.join(path.split('/')[0:3])
+        folder_id = self.folders[folder_name]
+        # Upload (caching the authorized `http` object used to run
+        # `next_chunk()`)
+        media = gah.MediaFileUpload(file_name, resumable=True)
+        file_metadata = {'name': path.split('/')[-1], 'parents': [folder_id]}
+        request = self.drive.files().create(body=file_metadata,
+                                            media_body=media, fields='id')
+        auth_http = _auth.authorized_http(self.creds)
+        auth_http.cache = httplib2.FileCache(self.cache_path)
+        response = None
+        while response is None:
+            status, response = request.next_chunk(num_retries=4, http=auth_http)
 
-    return
+        return

--- a/cryptostore/data/storage.py
+++ b/cryptostore/data/storage.py
@@ -22,7 +22,7 @@ class Storage(Store):
     @staticmethod
     def __init_helper(store, config):
         if store == 'parquet':
-            return Parquet(config.parquet if 'parquet' in config else None)
+            return Parquet(config.exchanges, config.parquet if 'parquet' in config else None)
         elif store == 'arctic':
             return Arctic(config.arctic)
         elif store == 'influx':

--- a/docs/google_drive.md
+++ b/docs/google_drive.md
@@ -1,7 +1,7 @@
 # Google Drive connector
 
 This connector uploads parquet files to a Google Drive folder.
-This documentation page introduces some prerequesites, and the way to setup:
+This documentation page introduces some prerequisites, and the way to setup:
   * a service account and to allow its access to your Google Drive storage space.
   * how to setup Cryptostore configuration file.
 

--- a/docs/google_drive.md
+++ b/docs/google_drive.md
@@ -1,11 +1,11 @@
 # Google Drive connector
 
 This connector uploads parquet files to a Google Drive folder.
-This documentation page introduces some prerequesties, and the way to setup:
+This documentation page introduces some prerequesites, and the way to setup:
   * a service account and to allow its access to your Google Drive storage space.
   * how to setup Cryptostore configuration file.
 
-Finally, a python script is also provided here below to list and remove all files written by the service account you will have setup, in case you would need it.
+Finally, a python script is also provided here below to list and remove all files written by this service account.
 
 ### Requirements
 
@@ -23,11 +23,11 @@ pip install --upgrade google-api-python-client
 
 2 steps are required to enable Google Drive connector to start uploading data to your storage space.
 
- * First, create a service account and a key as described in related [Google documentation](https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount).
+ * First, create a service account and its key as described in related [Google documentation](https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount).
    * Store the obtained key (_service-account-name-xxxx.json_ file) somewhere on your local hard drive. You will need to refer to this file in your configuration.
    * Note: it is not required to give this service account any role and permission if you follow the 2nd step proposed here below.
 
- * Second, once you've got your service account created, copy its email address you can see in this same page through which you created its key. You have to know that this service account you will use to authenticate Cryptostore's Google Drive connector will upload data in a space by default you have not access to. Storage space will however be taken from your own (parent) account. A workaround to be able to check and access manually this data through standard Google Drive interface is to share a folder in your Google Drive with this service account by using its email address. When sharing, give editor rights to the service account so that it can upload files.
+ * Second, once the service account created, copy its email address (provided in this same Google page). This service account will upload data in a space by default you have not access to. Storage space will however be taken from your own (parent) account. A workaround to be able to check and access manually this data through the standard Google Drive interface is to upload it in a folder shared with this service account by using its email address. When sharing, give editor rights to the service account so that it can upload files.
 
 ### Last configuration steps
 
@@ -45,7 +45,7 @@ Now that you have created both a service account and have its key stored on your
            service_account: '/path/to/key.json'
       ```
 
-  * Second, make sure to indicate to Cryptostore folder's name shared with the service account. Make also sure only one folder with this name is shared with the service account. If several folders exist, Google Drive connector will not be able to chose on its own and this will result in an error. Here below, this shared folder is named `Cryptostore` as an example.
+  * Second, indicate the folder's name shared with the service account. Make also sure only one folder with this name is shared with the service account. If several folders exist, Google Drive connector will not be able to chose on its own and this will result in an error. Here below, this folder is named `Cryptostore` as an example.
       ```yaml
           GD:
               prefix: 'Cryptostore'
@@ -56,7 +56,7 @@ Now that you have created both a service account and have its key stored on your
 The service account you have created is now sharing uploaded files with you through a shared folder.
 However, if you delete these files manually, they will still exist for your service account, and will still take storage space from your quota.
 
-To list these files and remove them for the service account, here is a script. It will connect to your space using service account credentials. Make sure to initialize correctly `service_account` and `prefix` variables located at the beginning of your script.
+Here is a script to list all these files and folders and remove them. It will connect to your space using service account credentials. Make sure to initialize correctly `service_account` and `prefix` variables located at the beginning of this script.
 
 ```python
 from google.oauth2 import service_account
@@ -68,50 +68,34 @@ prefix = 'Cryptostore'
 credentials = service_account.Credentials.from_service_account_file(service_account)
 scoped_credentials = credentials.with_scopes(['https://www.googleapis.com/auth/drive'])
 drive = discovery.build('drive', 'v3', credentials=scoped_credentials)
+files = drive.files()
 
 # List the files (except prefix)
-results = drive.files().list(
-    q="name != '" + prefix + "'",
-    fields="nextPageToken, files(id, name)").execute()
-items = results.get('files', [])
+file_list = []
+page_token = None
+while True:
+    res = files.list(q="name != '" + prefix + "'",
+                     pageSize=800, pageToken=page_token,
+                     fields='nextPageToken, files(id, name, parents)').execute()
+    file_list.extend(res.get('files', []))
+    page_token = res.get('nextPageToken', None)
+    if page_token is None:
+        break
 
-if not items:
+if not file_list:
     print('No files found.')
 else:
     print('Files:')
-    for item in items:
-        print(u'{0} ({1})'.format(item['name'], item['id']))
+    for file in file_list:
+        print(u'{0} ({1})'.format(file['name'], file['id']))
 
-# Remove these files
-for item in items:
-    print('Removing file {!s} with id {!s}'.format(item['name'], item['id']))
-    drive.files().delete(fileId=item['id']).execute()
-```
-
-If hundreds of files have to be trashed, re-run this script several times, as the number of files retrieved with the `list()` method is limited.
-
-### A note regarding thread safety (implementation detail).
-
-Stated in this [Google documentation page](https://github.com/googleapis/google-api-python-client/blob/master/docs/thread_safety.md#thread-safety), "_The google-api-python-client library is built on top of the httplib2 library, which is not thread-safe. Therefore, if you are running as a multi-threaded application, each thread that you are making requests from must have its own instance of httplib2.Http()._".
-
-Because of current implementation in Cryptostore, this workaround is not required. A new service object (named `drive` in the code) is created each time a file is uploaded.
-If ever this part of the code is refactored, and the `drive` object is eventually initialized only once at the start of Cryptostore, then it might be wise to follow recommendations from above-mentionned Google ressource.
-
-Following code makes this possible (I could not make working provided examples in Google ressource).
-
-```python
-# Initialization step of a would-be Google Drive connector object
-# to be run at the start of Cryptostore.
-# This line is currently in `_get_drive()` function.
-drive = discovery.build('drive', 'v3', credentials=scoped_credentials)
-
-# During runtime, creation of a new `http` object, to be used when
-# executing an http command.
-from googleapiclient import _auth
-new_http = _auth.authorized_http(scoped_credentials)
-# Example of such a command: listing files.
-results = drive.files().list(pageSize=10, fields="nextPageToken, files(id, name)")\
-                       .execute(http=new_http)
-
+# Batch delete
+call_limit = 800
+list_in_chunks = [file_list[x:x+call_limit] for x in range(0, len(file_list), call_limit)]
+for sub_list in list_in_chunks:
+    batch = drive.new_batch_http_request()
+    for file in sub_list:
+        batch.add(files.delete(fileId=file['id']))
+    batch.execute()
 ```
 


### PR DESCRIPTION
Hi @bmoscon 

I have managed a significant refactoring of the Google Drive connector with aim to drastically reduce the number of http requests / overhead.

In previous Google Drive connector version, number of http requests was:
- per recording loop and per exchange/data_type/pair to save, between 2 and 3 (3 if a folder had to be created in Google Drive, 2 otherwise).

The number of http requests is now:
- per recording loop : 1 to list up to 800 folders (1 more for each new 800 folders to list) + 1 to create possibly missing folders (1 more for each new 800 folders to create)
- per recording loop and per exchange/data_type/pair to save: 1 http request

Additionally, several 'performance' tips from Google documentation have been implemented:
- already in v1 of the connector:
    - [resumable upload](https://github.com/googleapis/google-api-python-client/blob/master/docs/media.md#resumable-media-chunked-upload)
- in v2:
    - [thread-safety](https://github.com/googleapis/google-api-python-client/blob/master/docs/thread_safety.md#thread-safety) (if ever recording data per exchange is multi-threaded?).
    - [pagination by use of `nextPageToken`](https://developers.google.com/drive/api/v3/search-files#python) when listing files & folders.
    - [caching is turned on at `httplib2` level](https://github.com/googleapis/google-api-python-client/blob/master/docs/performance.md#cache).
    - creation of folders is managed in [batch](https://github.com/googleapis/google-api-python-client/blob/master/docs/performance.md#batch) (to have a single http request per 800 folders to create)

Please, can you consider this pull request?

Thanks for your support,
Bests,