### PR TITLE
Implement parquet file appending.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,7 +95,8 @@ parquet:
     # writing to external store
     del_file: true
     # Append X times a parquet file before creating a new one to store data.
-    # This feature allows dumping frequently data from Redis, while writing less frequently new parquet files.
+    # This feature allows dumping frequently data from Redis (as defined by 'storage_interval'), while writing less frequently new parquet files.
+    # Remove this parameter or set it to 0 to write a new file each 'storage_interval' (appending is then disabled).
     # Beware that a parquet file not properly closed cannot be read back. Closing is made at the last appending iteration.
     append_counter: 4
     # File name format, as a list of arguments. Default is <exchange>-<data_type>-<pair>-<timestamp>.parquet, which would be exchange, data_type, pair, timestamp

--- a/config.yaml
+++ b/config.yaml
@@ -91,9 +91,13 @@ influx:
 
 # Parquet specific options. Parquet will default to storing the data on disk unless these are specified
 parquet:
-    # if storing the data to an external source (like S3) toggle this to enable the removal of the local file after
+    # If storing the data to an external source (like S3) toggle this to enable the removal of the local file after
     # writing to external store
     del_file: true
+    # Append X times a parquet file before creating a new one to store data.
+    # This feature allows dumping frequently data from Redis, while writing less frequently new parquet files.
+    # Beware that a parquet file not properly closed cannot be read back. Closing is made at the last appending iteration.
+    append_counter: 4
     # File name format, as a list of arguments. Default is <exchange>-<data_type>-<pair>-<timestamp>.parquet, which would be exchange, data_type, pair, timestamp
     # Can specify any combination exchange, data_type, pair, and timestamp
     # timestamp MUST be present.

--- a/cryptostore/aggregator/aggregator.py
+++ b/cryptostore/aggregator/aggregator.py
@@ -69,6 +69,7 @@ class Aggregator(Process):
                 else:
                     interval = 86400 * multiplier
 
+        parquet_buffer = dict()
         while True:
             start, end = None, None
             try:
@@ -79,7 +80,7 @@ class Aggregator(Process):
                         interval_start = end + timedelta(seconds=interval + 1)
                     start, end = get_time_interval(interval_start, base_interval, multiplier=multiplier)
                 if 'exchanges' in self.config and self.config.exchanges:
-                    store = Storage(self.config)
+                    store = Storage(self.config, parquet_buffer)
                     for exchange in self.config.exchanges:
                         for dtype in self.config.exchanges[exchange]:
                             # Skip over the retries arg in the config if present.

--- a/cryptostore/aggregator/aggregator.py
+++ b/cryptostore/aggregator/aggregator.py
@@ -80,7 +80,7 @@ class Aggregator(Process):
                         interval_start = end + timedelta(seconds=interval + 1)
                     start, end = get_time_interval(interval_start, base_interval, multiplier=multiplier)
                 if 'exchanges' in self.config and self.config.exchanges:
-                    store = Storage(self.config, parquet_buffer)
+                    store = Storage(self.config, parquet_buffer=parquet_buffer)
                     for exchange in self.config.exchanges:
                         for dtype in self.config.exchanges[exchange]:
                             # Skip over the retries arg in the config if present.

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -21,7 +21,7 @@ class Parquet(Store):
 
     default_path = lambda self, exchange, data_type, pair: f'{exchange}/{data_type}/{pair}'
 
-    def __init__(self, exchanges, buffer, config=None):
+    def __init__(self, exchanges, config=None, parquet_buffer=None):
         self._write = []
         self._read = []
         self._list = []
@@ -34,7 +34,7 @@ class Parquet(Store):
         self.path = None
         self.comp_codec = None
         self.comp_level = None
-        self.buffer = buffer
+        self.buffer = parquet_buffer
         if config:
             self.file_name = config.get('file_format')
             self.path = config.get('path')

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -21,7 +21,7 @@ class Parquet(Store):
 
     default_path = lambda self, exchange, data_type, pair: f'{exchange}/{data_type}/{pair}'
 
-    def __init__(self, exchanges, config=None):
+    def __init__(self, exchanges, buffer, config=None):
         self._write = []
         self._read = []
         self._list = []
@@ -30,18 +30,21 @@ class Parquet(Store):
         self.prefix = []
         self.data = None
         self.del_file = True
-        self.file_name = config.get('file_format') if config else None
-        self.path = config.get('path') if config else None
+        self.file_name = None
+        self.path = None
         self.comp_codec = None
         self.comp_level = None
-        if config and 'compression' in config:
-            self.comp_codec = config['compression']['codec']
-            if 'level' in config['compression']:
-                self.comp_level = config['compression']['level']
-
+        self.buffer = buffer
         if config:
+            self.file_name = config.get('file_format')
+            self.path = config.get('path')
             self.del_file = config.get('del_file', True)
-
+            # Compression
+            if 'compression' in config:
+                self.comp_codec = config['compression']['codec']
+                if 'level' in config['compression']:
+                    self.comp_level = config['compression']['level']
+            # Connectors
             if 'GCS' in config:
                 self._write.append(google_cloud_write)
                 self._read.append(google_cloud_read)
@@ -63,6 +66,8 @@ class Parquet(Store):
                 self.prefix.append(None)
                 self.bucket.append(None)
                 self.kwargs.append({'dummy': 'Dummy'})
+            # Counter
+            self.append_counter = config.get('append_counter') if 'append_counter' in config else 0
 
 
     def aggregate(self, data):
@@ -77,14 +82,16 @@ class Parquet(Store):
         table = pa.Table.from_arrays(arrays, names=names)
         self.data = table
 
+
     def write(self, exchange, data_type, pair, timestamp):
         if not self.data:
             return
         file_name = ''
+        timestamp = str(int(timestamp))
         if self.file_name:
             for var in self.file_name:
                 if var == 'timestamp':
-                    file_name += f"{int(timestamp)}-"
+                    file_name += f"{timestamp}-"
                 elif var == 'data_type':
                     file_name += f"{data_type}-"
                 elif var == "exchange":
@@ -95,22 +102,44 @@ class Parquet(Store):
                     raise ValueError("Invalid file format specified for parquet file")
             file_name = file_name[:-1] + ".parquet"
         else:
-            file_name = f'{exchange}-{data_type}-{pair}-{int(timestamp)}.parquet'
+            file_name = f'{exchange}-{data_type}-{pair}-{timestamp}.parquet'
 
-        if self.path:
-            file_name = os.path.join(self.path, file_name)
+        f_name_tips = tuple(file_name.split(timestamp))
 
-        pq.write_table(self.data, file_name, compression=self.comp_codec, compression_level=self.comp_level)
+        # Write parquet file and manage `counter`.
+        if f_name_tips not in self.buffer:
+            # Case 'create new parquet file'.
+            if self.path:
+                file_name = os.path.join(self.path, file_name)
+            writer = pq.ParquetWriter(file_name, self.data.schema, compression=self.comp_codec, compression_level=self.comp_level)
+            writer.write_table(table=self.data)
+            self.buffer[f_name_tips] = {'counter': 0, 'writer': writer, 'timestamp': timestamp}
+        else:
+            # Case 'append existing parquet file'.
+            writer = self.buffer[f_name_tips]['writer']
+            writer.write_table(table=self.data)
+            self.buffer[f_name_tips]['counter'] += 1
+
         self.data = None
 
-        if self._write:
-            for func, bucket, prefix, kwargs in zip(self._write, self.bucket, self.prefix, self.kwargs):
-                path = self.default_path(exchange, data_type, pair) + f'/{exchange}-{data_type}-{pair}-{int(timestamp)}.parquet'
-                if prefix:
-                    path = f"{prefix}/{path}"
-                func(bucket, path, file_name, **kwargs)
-            if self.del_file:
-                os.remove(file_name)
+        # If `append_counter` is reached, close parquet file and reset `counter`.
+        if self.buffer[f_name_tips]['counter'] == self.append_counter:
+            writer.close()
+            if self._write:
+                timestamp = self.buffer[f_name_tips]['timestamp']
+                file_name = f_name_tips[0] + timestamp + f_name_tips[1]
+                if self.path:
+                    file_name = os.path.join(self.path, file_name)
+                for func, bucket, prefix, kwargs in zip(self._write, self.bucket, self.prefix, self.kwargs):
+                    path = self.default_path(exchange, data_type, pair) + f'/{exchange}-{data_type}-{pair}-{timestamp}.parquet'
+                    if prefix:
+                        path = f"{prefix}/{path}"
+                    func(bucket, path, file_name, **kwargs)
+                if self.del_file:
+                    os.remove(file_name)
+            # Reset counter
+            del self.buffer[f_name_tips]
+
 
     def get_start_date(self, exchange: str, data_type: str, pair: str) -> float:
         objs = []

--- a/cryptostore/data/storage.py
+++ b/cryptostore/data/storage.py
@@ -12,17 +12,17 @@ from cryptostore.data.elastic import ElasticSearch
 
 
 class Storage(Store):
-    def __init__(self, config):
+    def __init__(self, config, parquet_buffer):
         self.config = config
         if isinstance(config.storage, list):
-            self.s = [Storage.__init_helper(s, config) for s in config.storage]
+            self.s = [Storage.__init_helper(s, config, parquet_buffer) for s in config.storage]
         else:
-            self.s = [Storage.__init_helper(config.storage, config)]
+            self.s = [Storage.__init_helper(config.storage, config, parquet_buffer)]
 
     @staticmethod
-    def __init_helper(store, config):
+    def __init_helper(store, config, parquet_buffer):
         if store == 'parquet':
-            return Parquet(config.exchanges, config.parquet if 'parquet' in config else None)
+            return Parquet(config.exchanges, parquet_buffer, config.parquet if 'parquet' in config else None)
         elif store == 'arctic':
             return Arctic(config.arctic)
         elif store == 'influx':

--- a/cryptostore/data/storage.py
+++ b/cryptostore/data/storage.py
@@ -12,17 +12,17 @@ from cryptostore.data.elastic import ElasticSearch
 
 
 class Storage(Store):
-    def __init__(self, config, parquet_buffer):
+    def __init__(self, config, **kwargs):
         self.config = config
         if isinstance(config.storage, list):
-            self.s = [Storage.__init_helper(s, config, parquet_buffer) for s in config.storage]
+            self.s = [Storage.__init_helper(s, config, **kwargs) for s in config.storage]
         else:
-            self.s = [Storage.__init_helper(config.storage, config, parquet_buffer)]
+            self.s = [Storage.__init_helper(config.storage, config, **kwargs)]
 
     @staticmethod
-    def __init_helper(store, config, parquet_buffer):
+    def __init_helper(store, config, **kwargs):
         if store == 'parquet':
-            return Parquet(config.exchanges, parquet_buffer, config.parquet if 'parquet' in config else None)
+            return Parquet(config.exchanges, config.parquet if 'parquet' in config else None, **kwargs)
         elif store == 'arctic':
             return Arctic(config.arctic)
         elif store == 'influx':


### PR DESCRIPTION
(original text from original PR)

Hi @bmoscon ,

This PR implements appending of parquet files, along with a counter that keeps track the number of times each parquet file is incremented.
This feature solves problem presented in #19 (albeit being not exactly the feature requested) and problem presented in #108.
This branch has been made over PR #105, so commit from from PR #105 is already in this PR.

**Implementation note 1**
There is one counter per exchange/data_type/pair data for coping up with the case of scarcely updated data. In this case, the appending rate of each file is not necessarily the same (when there is no data for a exchange/data_type/pair, this specific data is not dumped into parquet file as per legacy implementation). Each parquet file follows then its own appending rate, so to say.
(I implemented this feature actually in 3 different versions this week-end, and earlier versions used a single counter for all files)

**Implementation note 2**
As indicated in config file, a not closed parquet file cannot be read. But a closed file cannot be appended efficiently: it needs to be read 1st and re-written and left open. Then new data can be appended.
So if cryptostore is stopped for any reason, last files are very likely unreadable (it requires to stop cryptostore at the last appending iteration when it is also closed).

If it seems to you required, I could implement in a new PR a new option to be activated by the user in the config file to enforce closing parquet file after each appending.
Reading and re-writing operations will certainly consume more CPU and memory however.

I decided not to retain this approach as a baseline, but to retain the most efficient way. Between each appending, file is left open, and only closed when the appending_counter is reached.

An alternative would be to run the closing task as soon as cryptostore exits. I do not know where to implement this actually?
If you give me a pointer and think it is appropriate, I can do that in a subsequent PR.

**Implementation note 3**
Well, I guess you already had this in mind, but if implementing multi-threading for data writing, please, keep this line out of the multi-threading stuff.

Bests