### PR TITLE
Extend timeout for Google Drive connector from 1mn (default) to 10mn.

### DIFF
--- a/cryptostore/data/gd.py
+++ b/cryptostore/data/gd.py
@@ -5,6 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from typing import Tuple, Callable
+import socket
 
 from cryptostore.engines import StorageEngines
 from cryptostore.exceptions import InconsistentStorage
@@ -141,7 +142,6 @@ accessible folder.".format(prefix))
 
         """
 
-        socket = StorageEngines['socket']
         httplib2 = StorageEngines['httplib2']
 
         # Retrieve folder ID to be used to write the file into.

--- a/cryptostore/data/gd.py
+++ b/cryptostore/data/gd.py
@@ -141,6 +141,7 @@ accessible folder.".format(prefix))
 
         """
 
+        socket = StorageEngines['socket']
         httplib2 = StorageEngines['httplib2']
 
         # Retrieve folder ID to be used to write the file into.
@@ -155,6 +156,8 @@ accessible folder.".format(prefix))
         request = self.drive.files().create(body=file_metadata,
                                             media_body=media, fields='id')
         googleapiclient = StorageEngines['googleapiclient._auth']
+        # Set timeout to 10 minutes for upload of big chunks (is used when creating the `http` object)
+        socket.setdefaulttimeout(600)
         auth_http = googleapiclient._auth.authorized_http(self.creds)
         auth_http.cache = httplib2.FileCache(self.cache_path)
         response = None


### PR DESCRIPTION
Hi @bmoscon,

With use of Parquet file appending, parquet files tend to be bigger, and time to upload them to Google Drive connector increase.
By default, the http connection created has a timeout set to 1mn, which is too short for uploading big files (for instance order books).
I have increased this timeout to 10mn and got no time out error any more with this duration.

Bests,