### PR TITLE
Optimization of Redis.read() method (CPU & memory).

### DIFF
--- a/cryptostore/aggregator/redis.py
+++ b/cryptostore/aggregator/redis.py
@@ -6,12 +6,11 @@ associated with this software.
 '''
 import logging
 from collections import defaultdict
-import json
 import time
 
 from cryptofeed.defines import TRADES, L2_BOOK, L3_BOOK, TICKER, FUNDING, OPEN_INTEREST
 
-from cryptostore.aggregator.util import book_flatten
+from cryptostore.aggregator.util import l2_book_flatten, l3_book_flatten
 from cryptostore.aggregator.cache import Cache
 from cryptostore.engines import StorageEngines
 
@@ -34,8 +33,22 @@ class Redis(Cache):
 
 
     def read(self, exchange, dtype, pair, start=None, end=None):
-        key = f'{dtype}-{exchange}-{pair}'
+        """
+        Read list of JSON dictionaries from Redis buffer, flatten the dictionaries and transform all
+        float stored as string into Python float.
+        Data is then returned either as a tuple of dictionaries or as a tuple containing for 1st element
+        keys of the dictionaries, and for 2nd element a generator yielding said dictionaries.
+        This is depending `dtype`.
+        
+        Returns:
+            updates (tuple[dict] or Tuple[tuple, Generator):
+                Tuple of dictionaries when `dtype` is not a L2 or L3 book.
+                Tuple of the tuple of keys as 1st element, and as 2nd element a generator yielding
+                dictionaries when `dtype` is a L2 or L3 book.
 
+        """
+
+        key = f'{dtype}-{exchange}-{pair}'
         if start and end:
             data = [[key, self.conn.xrange(key, min=start, max=end)]]
         else:
@@ -45,34 +58,29 @@ class Redis(Cache):
             return []
 
         LOG.info("%s: Read %d messages from Redis", key, len(data[0][1]))
-        ret = []
-
-        for update_id, update in data[0][1]:
-            if dtype in {L2_BOOK, L3_BOOK}:
-                update = json.loads(update['data'])
-                update = book_flatten(update, update['timestamp'], update['receipt_timestamp'], update['delta'])
-                for u in update:
-                    for k in ('size', 'amount', 'price', 'timestamp', 'receipt_timestamp'):
-                        if k in u:
-                            u[k] = float(u[k])
-                ret.extend(update)
-            elif dtype in {TRADES, TICKER, OPEN_INTEREST}:
-                for k in ('size', 'amount', 'price', 'timestamp', 'receipt_timestamp', 'bid', 'ask', 'open_interest'):
-                    if k in update:
-                        update[k] = float(update[k])
-                ret.append(update)
-            elif dtype == FUNDING:
+        self.ids[key], updates = tuple(zip(*data[0][1]))
+        self.last_id[key] = self.ids[key][-1]
+        if dtype == L2_BOOK:
+            updates = l2_book_flatten(updates)
+        elif dtype == L3_BOOK:
+            updates = l3_book_flatten(updates)
+        elif dtype in {TRADES, TICKER, OPEN_INTEREST}:
+            as_float = ('size', 'amount', 'price', 'timestamp', 'receipt_timestamp', 'bid', 'ask', 'open_interest')
+            are_float = filter(as_float.count, updates[0])
+            for k in are_float:
+                for update in updates:
+                    update[k] = float(update[k])
+        elif dtype == FUNDING:
+            for update in updates:
                 for k in update:
                     try:
                         update[k] = float(update[k])
                     except ValueError:
                         # ignore strings
                         pass
-                ret.append(update)
-            self.ids[key].append(update_id)
 
-        self.last_id[key] = self.ids[key][-1]
-        return ret
+        return updates
+
 
     def delete(self, exchange, dtype, pair):
         key = f'{dtype}-{exchange}-{pair}'

--- a/cryptostore/aggregator/util.py
+++ b/cryptostore/aggregator/util.py
@@ -4,12 +4,14 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+from typing import Tuple, Generator
+import json
 from cryptofeed. defines import BID, ASK
 
 
 def book_flatten(book: dict, timestamp: float, receipt_timestamp: float, delta: str) -> dict:
     """
-    takes book and returns a list of dict, where each element in the list
+    Takes book and returns a list of dict, where each element in the list
     is a dictionary with a single row of book data.
 
     eg.
@@ -29,3 +31,57 @@ def book_flatten(book: dict, timestamp: float, receipt_timestamp: float, delta: 
             else:
                 ret.append({'side': side, 'price': price, 'size': data, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp, 'delta': delta})
     return ret
+
+
+def l2_book_flatten(data: Tuple[dict]) -> Tuple[tuple, Generator]:
+    """
+    Take a tuple of dict (containing nested dict), and returns a generator
+    yielding flattened dicts, i.e. where each element is a dictionary with a
+    single row of book data.
+
+    Returns:
+      -  data (Generator[dict]):
+         L2 book generator:
+         ({'side': str, 'price': float, 'size': float, 'timestamp': float, 'receipt_timestamp': float}, {...}, ...)
+      -  keys (tuple):
+         Keys of the dictionaries are also returned in a tuple to prevent having to touch the generator only for
+         having this information (is used for instance for `parquet` and `artctic` backends).
+    """
+
+    data = map(json.loads, [d['data'] for d in data])
+    data = ({'timestamp':float(ts), 'receipt_timestamp':float(r_ts), 'delta': delta, 'side':side,
+             'price': float(price), 'size':float(size)} \
+            for trans in data                                                                          \
+            for ts, r_ts, delta in ((trans['timestamp'], trans['receipt_timestamp'], trans['delta']),) \
+            for side in (BID, ASK)                                                                     \
+            for price, size in trans[side].items()                                                     )
+    keys=('timestamp','receipt_timestamp', 'delta', 'side', 'price', 'size')
+    return keys, data
+
+
+def l3_book_flatten(data: Tuple[dict]) -> Tuple[tuple, Generator]:
+    """
+    Take a tuple of dict (containing nested dict), and returns a generator
+    yielding flattened dicts, i.e. where each element is a dictionary with a
+    single row of book data.
+
+    Returns:
+      -  data (Generator[dict]):
+         L3 book generator:
+         ({'side': str, 'price': float, 'size': float, 'timestamp': float, 'receipt_timestamp': float, 'order_id': str}, {...}, ...)
+      -  keys (tuple):
+         Keys of the dictionaries are also returned in a tuple to prevent having to touch the generator only for
+         having this information (is used for instance for `parquet` and `artctic` backends).
+    """
+
+    data = map(json.loads, [d['data'] for d in data])
+    data = ({'timestamp':float(ts), 'receipt_timestamp':float(r_ts), 'delta': delta, 'side':side,
+             'price': float(price), 'size':float(size), 'order_id': order_id} \
+            for trans in data                                                                          \
+            for ts, r_ts, delta in ((trans['timestamp'], trans['receipt_timestamp'], trans['delta']),) \
+            for side in (BID, ASK)                                                                     \
+            for price, dat in trans[side].items()                                                      \
+            for order_id, size in dat.items()                                                          )
+    keys=('timestamp','receipt_timestamp', 'delta', 'side', 'price', 'size', 'order_id')
+    return keys, data
+

--- a/cryptostore/data/arctic.py
+++ b/cryptostore/data/arctic.py
@@ -17,18 +17,23 @@ class Arctic(Store):
         self.con = StorageEngines.arctic.Arctic(connection)
 
     def aggregate(self, data):
-        self.data = data
+        if isinstance(data[0], dict):
+            # Case `data` is a list or tuple of dict.
+            self.data = pd.DataFrame(data)
+        else:
+            # Case `data` is a tuple with tuple of keys of dict as 1st parameter,
+            # and generator of dicts as 2nd paramter.
+            # DataFrame creation is faster by more than 10% if column names are provided.
+            self.data = pd.DataFrame(data[1], columns=data[0])
 
     def write(self, exchange, data_type, pair, timestamp):
         chunk_size = None
         if not self.data:
             return
-        df = pd.DataFrame(self.data)
-        self.data = []
 
+        df = self.data
         df['date'] = pd.to_datetime(df['timestamp'], unit='s')
         df['receipt_timestamp'] = pd.to_datetime(df['receipt_timestamp'], unit='s')
-
         df = df.drop(['timestamp'], axis=1)
 
         if data_type == TRADES:

--- a/cryptostore/data/elastic.py
+++ b/cryptostore/data/elastic.py
@@ -36,7 +36,14 @@ class ElasticSearch(Store):
                         }
 
     def aggregate(self, data):
-        self.data = data
+        if isinstance(data[0], dict):
+            # Case `data` is a list or tuple of dict.
+            self.data = data
+        else:
+            # Case `data` is a tuple with tuple of keys of dict as 1st parameter,
+            # and generator of dicts as 2nd paramter.
+            # Data is transformed back into a list of dict
+            self.data = list(data[1])
 
     def write(self, exchange, data_type, pair, timestamp):
         if requests.head(f"{self.host}/{data_type}").status_code != 200:

--- a/cryptostore/data/influx.py
+++ b/cryptostore/data/influx.py
@@ -30,7 +30,14 @@ class InfluxDB(Store):
             r.raise_for_status()
 
     def aggregate(self, data):
-        self.data = data
+        if isinstance(data[0], dict):
+            # Case `data` is a list or tuple of dict.
+            self.data = data
+        else:
+            # Case `data` is a tuple with tuple of keys of dict as 1st parameter,
+            # and generator of dicts as 2nd paramter.
+            # Data is transformed back into a list of dict
+            self.data = data[1]
 
     def write(self, exchange, data_type, pair, timestamp):
         if not self.data:

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -66,9 +66,16 @@ class Parquet(Store):
 
 
     def aggregate(self, data):
-        names = list(data[0].keys())
+        if isinstance(data[0], dict):
+            # Case `data` is a list or tuple of dict.
+            names = list(data[0].keys())
+        else:
+            # Case `data` is a tuple with tuple of keys of dict as 1st parameter,
+            # and generator of dicts as 2nd paramter.
+            names = data[0]
+            data = data[1]
+           
         cols = {name: [] for name in names}
-
         for entry in data:
             for key in entry:
                 val = entry[key]

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -68,7 +68,7 @@ class Parquet(Store):
     def aggregate(self, data):
         if isinstance(data[0], dict):
             # Case `data` is a list or tuple of dict.
-            names = list(data[0].keys())
+            names = list(data[0])
         else:
             # Case `data` is a tuple with tuple of keys of dict as 1st parameter,
             # and generator of dicts as 2nd paramter.


### PR DESCRIPTION
Hi @bmoscon,

Here is a PR to improve performances (CPU & memory) of `Redis.read()`.
I tested a lot of different parameters and I finally dissociated the cases between order book, and the other types of data.
To measure CPU and memory performances, I used `%timeit` and `%memit`.

## I. Case `dtype` != `order_book`
I kept the way it was coded, but improved slighlty the code:
- removing `if` by using built-in function `filter`
- removing useless `append` command

For this, I noticed the following changes:
- **no memory change**,
- in terms of execution time (`read()` method without considering time to actually load data from Redis):
     - `trades`:            45% time saving
     - `ticker`:              40% time saving
     - `open_interest`: 55% time saving
     - `funding`:           55% time saving

## II. Case `dtype` == `order_book` (L2 or L3)
This case has been more difficult to handle.
Of course, recipe used above (removing `if` from `for` loop) is positive.
But to go further, I also tried to change the output format.

I got 1st interesting results switching the output format from list of dictionaries to list of list (and even better of course list of tuples), in this case, storing the keys in the 1st list.
However, the backends do not use the data all the same way afterwards.

And while this format was very effective for `Arctic` and `Parquet` (both in terms of CPU and memory) , it was not so much for `Influx` and `Elastic` which need a list of dictionaries.
For these 2 latter, the time saved during `Redis.read()` was then more or less lost again in `Influx.aggregate()` and `Elastic.aggregate()` that had then to manage the transformation `list of list` to `list of dict`.

I was about to give up, when I made a last try with `generator`. This last try is in my opinion the one to keep.

Here are the results. In terms of CPU, it is not so impressive, but it seems nice to me in terms of memory.
To compare, I have been reproducing the full processing once data is loaded from Redis buffer:
- processing in `Redis.read()`,
- complementary processing in `Store.aggregate()` to get the data in the right format.

So for `l2_book`:
  * `Parquet`  (`pa.Table` format)
            - execution time: -30%
            - peak memory: -55%   (with sample data, from 2GB to 0,9 GB)
  * `Arctic`    (`pd.DataFrame` format)
            - execution time: -30%
            - peak memory: -20%
  * `Elastic`   (list of dictionaries)     [ see note below]
            - execution time: -5%
            - peak memory: -20%
  * `Influx`     (generator yielding dictionaries)
            - execution time: not assessed, possibly -30% (similar to `Parquet`) or even more
            - peak memory:  not assessed, possibly -55% (similar to `Parquet`) or even more

Having no `Influx` backend, I have not been able to test the `write()` step that would be needed to really assess the savings.
Thing is that `Influx` case is the optimal case. In `write()`, the iterable is simply iterated in a for loop. This is just the dream case for a generator.

**Note for `Elastic`**
In `Elastic.write()` the iterable of dictionaries goes 1st through a `chunk()` function.
I did not have a deep look, but I think that with some modifications, the generator could be here also directly used (like `Influx`).
Not having `Elastic`, I did not wanted to be too brave in this file. (ok, possibly, "lazzy me" as well)

## Last word
Using `Parquet` backend, and after having implemented `appending`, the real bottleneck I actually have is the peak memory required to process the order books (that cannot be reduced by any parameter when the trouble arises with order book full snapshot).

So i am happy I could reduce it somewhat with use of a `generator`.

Bests