### PR TITLE
Parquet file content optimization

### DIFF
--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -67,13 +67,16 @@ class Parquet(Store):
 
     def aggregate(self, data):
         names = list(data[0].keys())
+        names = [name for name in names if name not in ('feed', 'pair')]
         cols = {name: [] for name in names}
 
         for entry in data:
-            for key in entry:
+            for key in names:
                 val = entry[key]
                 cols[key].append(val)
-        arrays = [pa.array(cols[col]) for col in cols]
+
+        arrays = [pa.array(cols[col], pa.string()).dictionary_encode() if col == 'side'
+                  else pa.array(cols[col]) for col in cols]
         table = pa.Table.from_arrays(arrays, names=names)
         self.data = table
 

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -67,7 +67,6 @@ class Parquet(Store):
 
     def aggregate(self, data):
         names = list(data[0].keys())
-        names = [name for name in names if name not in ('feed', 'pair')]
         cols = {name: [] for name in names}
 
         for entry in data:
@@ -75,7 +74,8 @@ class Parquet(Store):
                 val = entry[key]
                 cols[key].append(val)
 
-        arrays = [pa.array(cols[col], pa.string()).dictionary_encode() if col == 'side'
+        to_dict = ('feed', 'pair', 'side')
+        arrays = [pa.array(cols[col], pa.string()).dictionary_encode() if col in to_dict
                   else pa.array(cols[col]) for col in cols]
         table = pa.Table.from_arrays(arrays, names=names)
         self.data = table

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -70,7 +70,7 @@ class Parquet(Store):
         cols = {name: [] for name in names}
 
         for entry in data:
-            for key in names:
+            for key in entry:
                 val = entry[key]
                 cols[key].append(val)
 


### PR DESCRIPTION
Hi @bmoscon @xiandong79 @joelrich 

Xian, Joel, I see you have contributed to `parquet.py`, so your feedback would be nice to have.

The code of this commit optimizes in size the parquet tables.
  - similarly to what is done for `Arctic` backend when Panda DataFrame is generated, columns `feed` and `pair` are dropped. This information is indeed already provided in the file name.
  - further, the `side` information (which has only 2 values, either `buy` or `sell` for `trades`; or `bid` and `ask` for `order_book`) is stored as an Arrow `dictionary` which corresponds to Pandas `category`. So in short, it is ultra efficient.
 
To users of `parquet` file, is it ok?
I think it makes sense to do similarly to `Arctic` backend regarding the removal of `feed` and `pair`, but then, let everybody says for himself.
An alternative instead of dropping could be to store the information as `dictionary` as well.

Bests,