### PR TITLE
Limit mongodb cache/memory usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - 6379
     command: ["redis-server", "--save", "''", "--appendonly", "no"]
   mongo:
+    deploy:
+      resources:
+        limits:
+          memory: 2G
     logging:
       driver: "json-file"
       options:
@@ -31,3 +35,4 @@ services:
       - '37017:27017'
     expose:
       - 27017
+    command: ["mongod", "--wiredTigerCacheSizeGB", "0.25"]


### PR DESCRIPTION
this allows for development and deployments on small (4G) cloud instances

Previously the default docker compose setup would regularly run out of memory within 24hours when fetching order books from 3 different exchanges. Using this configuration the mongo process is limited to less than 2G memory, specifically it is using the absolute minimum of 256M file storage cache. This should be enough for most scenarios involving a few concurrent readers and writers (<100) as the average blob size stored by arctic is less than 1M.
