### PR TITLE
arctic: default library quota set to unlimited

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   * Feature: Option to enable parquet file appending
   * Feature: Retry writes to storage engines (rather than dying).
   * Feature: Support for snapshot_interval
+  * Bugfix: Set arctic storage quota to unlimited (rather than 10G)
 
 ### 0.3.0 (2020-08-18)
   * Feature: Config options for controlling data channel timeouts

--- a/cryptostore/data/arctic.py
+++ b/cryptostore/data/arctic.py
@@ -58,6 +58,8 @@ class Arctic(Store):
         df.index = df.index.tz_localize(None)
         if exchange not in self.con.list_libraries():
             self.con.initialize_library(exchange, lib_type=StorageEngines.arctic.CHUNK_STORE)
+            # set the quota of each arctic library to unlimited
+            self.con.set_quota(exchange, 0)
         self.con[exchange].append(f"{data_type}-{pair}", df, upsert=True, chunk_size=chunk_size)
 
     def get_start_date(self, exchange: str, data_type: str, pair: str) -> float:


### PR DESCRIPTION
arctic: default library quota set to unlimited

- [ ] - Tested
- [x] - Changelog updated
