### PR TITLE
Additional parquet storage features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   * Feature: Option to enable parquet file appending
   * Feature: Retry writes to storage engines (rather than dying).
   * Feature: Support for snapshot_interval
+  * Feature: Parquet files can be stored in directories per day
   * Bugfix: Set arctic storage quota to unlimited (rather than 10G)
   * Bugfix: Regression in arctic storage backend
 

--- a/config.yaml
+++ b/config.yaml
@@ -125,10 +125,11 @@ parquet:
     compression:
         codec: 'BROTLI'
         level: 6
-    # Path controls where the file is written (if not using S3/GC) If null, will write to CWD. Must be absolute path. The path must also exist, Cryptostore will not
-    # create the path.
+    # Path controls where the file is written (if not using S3/GC) If null, will write to CWD. Must be absolute path.
     path: null
-
+    # Automatically groups all paquet files in a folder YYYY-MM-DD both on the local filesystem, as well as on the cloud storage engine.
+    # Setting prefix on the cloud storage engine will override this setting.
+    prefix_date: false
 
     S3:
         # endpoint allows you to override the write endpoint and write to other provicers that have the same API interface

--- a/cryptostore/aggregator/aggregator.py
+++ b/cryptostore/aggregator/aggregator.py
@@ -106,6 +106,15 @@ class Aggregator(Process):
                                         # retrying this is ok, provided every
                                         # engine clears its internal buffer after writing successfully.
                                         store.write(exchange, dtype, pair, time.time())
+                                    except OSError as e:
+                                        if e.errno == 112: # Host is down
+                                            LOG.warning('Could not write %s-%s-%s. %s', exchange, dtype, pair, e)
+                                            retries += 1
+                                            await asyncio.sleep(self.config.storage_retry_wait)
+                                            continue
+                                        else:
+                                            raise
+
                                     except EngineWriteError:
                                         retries += 1
                                         await asyncio.sleep(self.config.storage_retry_wait)

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -119,7 +119,7 @@ class Parquet(Store):
 
         f_name_tips = tuple(file_name.split(timestamp))
 
-        if self.prefix_date:
+        if self.path and self.prefix_date:
             date = str(datetime.date.fromtimestamp(int(timestamp)))
             local_path = os.path.join(self.path, date)
         else:


### PR DESCRIPTION
1. Config variable `prefix_date` allows to group all files by the current date. This prevents the parquet files from reaching filesystem limits for files in a single folder.
2. Config variable `path` now auto-creates it's target directory
3.Handle network timeouts on filesystems (e.g. nfs) with a retry

- [x] - Tested
- [x] - Changelog updated
