### PR TITLE
Gather temporary parquet files within a seperate temp folder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### 0.3.1
+  * Bugfix: Aggregating parquet files at the end of time no longer causes file not found error. 
+  * Feature: Temporary parquet files are now gathering in a seperate folder
   * Feature: Influxdb 1.x authentication support
   * Bugfix: Extend timeout of Google Drive connection
   * Feature: Parquet file compression

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -133,9 +133,7 @@ class Parquet(Store):
             file_name += '.tmp' if self.append_counter else ''
 
             if self.path:
-                if self.append_counter:
-                    os.makedirs(save_path, mode=0o755, exist_ok=True)
-                os.makedirs(local_path, mode=0o755, exist_ok=True)
+                os.makedirs(save_path, mode=0o755, exist_ok=True)
                 save_path = os.path.join(save_path, file_name)
             
             writer = pq.ParquetWriter(save_path, self.data.schema, compression=self.comp_codec, compression_level=self.comp_level)
@@ -156,8 +154,7 @@ class Parquet(Store):
                 timestamp = self.buffer[f_name_tips]['timestamp']
                 file_name = f_name_tips[0] + timestamp + f_name_tips[1]
                 if self.path:
-                    if not os.path.exists(local_path):
-                        os.makedirs(local_path, mode=0o755, exist_ok=True)
+                    os.makedirs(local_path, mode=0o755, exist_ok=True)
                     final_path = os.path.join(local_path, file_name)
                 if self.append_counter:
                     # Remove '.tmp' suffix

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -125,7 +125,7 @@ class Parquet(Store):
         else:
             local_path = self.path
 
-        save_path = os.path.join(local_path, "temp") if self.append_counter else local_path
+        save_path = os.path.join(self.path, "temp") if self.append_counter else local_path
         if self.append_counter:
             os.makedirs(save_path, mode=0o755, exist_ok=True)
 

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -156,6 +156,8 @@ class Parquet(Store):
                 timestamp = self.buffer[f_name_tips]['timestamp']
                 file_name = f_name_tips[0] + timestamp + f_name_tips[1]
                 if self.path:
+                    if not os.path.exists(local_path):
+                        os.makedirs(local_path, mode=0o755, exist_ok=True)
                     final_path = os.path.join(local_path, file_name)
                 if self.append_counter:
                     # Remove '.tmp' suffix


### PR DESCRIPTION
Gathers temporary parquet files within a seperate temp folder. This is a more convenient way to create and aggregate temporary files and expected to eliminate "FileNotFound" error caused by end-of-the-day parquet file aggregation. Solves #128 

- [x] - Tested
- [X] - Changelog updated
