### PR TITLE
Name of parquet file is retrieved directly from ParquetWriter object.

### DIFF
--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -146,7 +146,7 @@ class Parquet(Store):
         # If `append_counter` is reached, close parquet file and reset `counter`.
         if self.buffer[f_name_tips]['counter'] == self.append_counter:
             # File name with path
-            file_name = writer.file_handle.name
+            file_name = writer.where
             writer.close()
             if self.append_counter:
                 # Remove '.tmp' suffix


### PR DESCRIPTION
### Description of code: correct use of `ParquetWriter` property to retrieve parquet filename

- [x] - Tested
- [ ] - Changelog updated

Clean implementation in `parquet.py` to retrieve parquet file name using already availabel `file_handle` property.
Solves at the same time issue #128 .