### PR TITLE
Update influx.py

### DIFF
--- a/cryptostore/data/influx.py
+++ b/cryptostore/data/influx.py
@@ -95,7 +95,7 @@ class InfluxDB(Store):
         elif data_type == LIQUIDATIONS:
             for entry in self.data:
                 ts = int(Decimal(entry["timestamp"]) * 1000000000)
-                agg.append(f'{data_type}-{exchange},pair={pair},exchange={exchange} side="{entry["side"]}",leaves_qty={entry["leaves_qty"]},order_id="{entry["order_id"]}",price="{entry["price"]}",timestamp={entry["timestamp"]},receipt_timestamp={entry["receipt_timestamp"]} {ts}')
+                agg.append(f'{data_type}-{exchange},pair={pair},exchange={exchange} side="{entry["side"]}",leaves_qty={entry["leaves_qty"]},order_id="{entry["order_id"]}",price={entry["price"]},timestamp={entry["timestamp"]},receipt_timestamp={entry["receipt_timestamp"]} {ts}')
 
         # https://v2.docs.influxdata.com/v2.0/write-data/best-practices/optimize-writes/
         # Tuning docs indicate 5k is the ideal chunk size for batch writes


### PR DESCRIPTION
Little change because in Influx, the **fieldType** for the fieldKey "price" was : **string** , after this update, the **fieldType** is : **float**.
Example before :  
name: liquidations-BITMEX
fieldKey          fieldType
--------          ---------
leaves_qty        float
order_id          string
**price             string**
receipt_timestamp float
side              string
timestamp         float


After : 
name: liquidations-BITMEX
fieldKey          fieldType
--------          ---------
leaves_qty        float
order_id          string
**price             float**
receipt_timestamp float
side              string
timestamp         float

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
