### PR TITLE
Feature: Optionally pull config file from S3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,9 @@
 ## Changelog
 
-### PR
-  * Feature: Ability to pull config file from S3 bucket instead of local filesystem, polling for updated config is supported.
 
 ### 0.3.2
   * Bugfix: Fix book building example
+  * Feature: Ability to pull config file from S3 bucket instead of local filesystem, polling for updated config is supported.
 
 ### 0.3.1 (2020-11-14)
   * Feature: Influxdb 1.x authentication support

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### PR
+  * Feature: Ability to pull config file from S3 bucket instead of local filesystem, polling for updated config is supported.
+
 ### 0.3.2
   * Bugfix: Fix book building example
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install --no-cache-dir pyarrow
 RUN pip install --no-cache-dir redis
 RUN pip install --no-cache-dir aioredis
 RUN pip install --no-cache-dir arctic
+RUN pip install --no-cache-dir boto3
 
 ## Add any extra dependencies you might have
 # eg RUN pip install --no-cache-dir boto3

--- a/cryptostore/config.py
+++ b/cryptostore/config.py
@@ -59,7 +59,7 @@ class DynamicConfig(Config):
         self.s3_region     = os.environ.get('S3_REGION') #returns None if env var not present
         LOG.debug(f'self.s3_object_uri is: {self.s3_object_uri}')
 
-        if self.s3_object_uri is (None or ''):
+        if not self.s3_object_uri:
             if file_name is None:
                 file_name = os.path.join(os.getcwd(), 'config.yaml')
             if not os.path.isfile(file_name):
@@ -80,13 +80,10 @@ class DynamicConfig(Config):
             self.config = {}
             self._load(self.s3_object_uri, reload_interval, callback)
 
-        self.config = {}
-        self._load(file_name, reload_interval, callback)
-
     async def __loader(self, file, interval, callback):
         last_modified = 0
         last_modified_date = datetime(1990, 1, 1)
-        if file is not None:
+        if file:
             while True:
                 if file[0:5] != 's3://':
                     LOG.info(f'loading config file locally: {file} at {datetime.utcnow()}' )

--- a/cryptostore/config.py
+++ b/cryptostore/config.py
@@ -5,9 +5,15 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import asyncio
+import logging
 import os
+from datetime import datetime
+from urllib.parse import urlparse
 
+import boto3
 import yaml
+
+LOG = logging.getLogger('cryptostore')
 
 
 class AttrDict(dict):
@@ -45,24 +51,60 @@ class Config:
 
 class DynamicConfig(Config):
     def __init__(self, file_name=None, reload_interval=10, callback=None):
-        if file_name is None:
-            file_name = os.path.join(os.getcwd(), 'config.yaml')
-        if not os.path.isfile(file_name):
-            raise FileNotFoundError(f"Config file {file_name} not found")
+        # Normal boto3 credentialing methods are used (see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
+
+        self.s3_object_uri = os.environ.get('S3_CONFIG_FILE_URI') #returns None if env var not present
+        self.s3_region     = os.environ.get('S3_REGION') #returns None if env var not present
+        if self.s3_object_uri is None:
+            if file_name is None:
+                file_name = os.path.join(os.getcwd(), 'config.yaml')
+            if not os.path.isfile(file_name):
+                raise FileNotFoundError(f"Config file {file_name} not found")
+        else:
+            self.s3client = boto3.client('s3', region_name=self.s3_region)
+            s3_uri = urlparse(self.s3_object_uri)
+            self.s3_bucket_name = s3_uri.netloc
+            self.s3_object_name = s3_uri.path.lstrip('/')
+
+            obj = self.s3client.get_object(Bucket=self.s3_bucket_name,
+                                           Key=self.s3_object_name)
+            if obj['ResponseMetadata']['HTTPStatusCode'] != 200:
+                raise FileNotFoundError(f"Failed trying to load config file {s3_uri}. Response metadata: {obj['ResponseMetadata']}")
 
         self.config = {}
         self._load(file_name, reload_interval, callback)
 
     async def __loader(self, file, interval, callback):
         last_modified = 0
+        last_modified_date = datetime(1990, 1, 1)
         while True:
-            cur_mtime = os.stat(file).st_mtime
-            if cur_mtime != last_modified:
-                with open(file, 'r') as fp:
-                    self.config = AttrDict(yaml.load(fp, Loader=yaml.FullLoader))
-                    if callback is not None:
-                        await callback(self.config)
-                    last_modified = cur_mtime
+            if self.s3_object_uri is None:
+                LOG.info(f'loading config file locally: {file}')
+                cur_mtime = os.stat(file).st_mtime
+                if cur_mtime != last_modified:
+                    with open(file, 'r') as fp:
+                        self.config = AttrDict(yaml.load(fp, Loader=yaml.FullLoader))
+                        LOG.info('applying local config file')
+                        if callback is not None:
+                            await callback(self.config)
+                        last_modified = cur_mtime
+            else:
+                LOG.info(f'loading config from s3 {self.s3_object_uri}')
+
+                try:
+                    obj = self.s3client.get_object(Bucket=self.s3_bucket_name,
+                                                   Key=self.s3_object_name)
+
+                    if obj['ResponseMetadata']['HTTPStatusCode'] == 200:
+                        if obj['LastModified'].replace(tzinfo=None) > last_modified_date.replace(tzinfo=None):
+                            self.config = AttrDict(yaml.load(obj['Body'].read().decode('utf-8'), Loader=yaml.FullLoader))
+                            LOG.info('applying config file from S3')
+                            if callback is not None:
+                                await callback(self.config)
+                            last_modified_date = obj['LastModified']
+
+                except Exception as e:
+                    LOG.info(f'Exception in getting s3 object. {e}')
 
             await asyncio.sleep(interval)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.7"
 services:
   cryptostore:
+    env_file:
+      - env.s3config
     logging:
       driver: "json-file"
       options:

--- a/env.s3config
+++ b/env.s3config
@@ -1,0 +1,9 @@
+#S3_REGION=us-east-1
+
+##### S3_CONFIG_FILE must use S3 URI. Ex: s3://bucket-for-all-my-config-files/config-docker.yaml
+#S3_CONFIG_FILE_URI=s3://bucket-for-all-my-configs/config-docker.yaml
+
+###### Configure IAM user and IAM secret. Boto3 is used internally. If you have set the credentials through a different method, you may leave these blank. These will be passed as env variables to the cryptostore container by specifying this filename in docker-compose.yaml
+#AWS_ACCESS_KEY_ID=x
+#AWS_SECRET_ACCESS_KEY=x
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 pandas
 cryptofeed>=1.3.1
 pyyaml


### PR DESCRIPTION
### Added feature to optionally pull config file from S3 bucket instead of local filesystem, Polling for updated config is supported. Uses boto3, and uses a local env file for configuration (although it doesn't really matter how the user chooses to set the env vars, as long as they are set. User must edit config file, then pass the env file to the container using docker commands. S3 object is checked for updates, defaults to every 10s. This allows the user to change the config without ever touching the system running cryptostore.

Example of usage with docker-compose:
```
 docker-compose --env-file env.s3config up
```

Example of usage with Dockerfile:
```
docker run --env-file env.s3config cryptostore
```


- [X] - Tested
- [X] - Changelog updated
