### PR TITLE
on-demand imports for storage implementations (parquet, influx, …

### DIFF
--- a/cryptostore/data/storage.py
+++ b/cryptostore/data/storage.py
@@ -5,10 +5,6 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptostore.data.store import Store
-from cryptostore.data.parquet import Parquet
-from cryptostore.data.arctic import Arctic
-from cryptostore.data.influx import InfluxDB
-from cryptostore.data.elastic import ElasticSearch
 
 
 class Storage(Store):
@@ -22,12 +18,16 @@ class Storage(Store):
     @staticmethod
     def __init_helper(store, config, **kwargs):
         if store == 'parquet':
+            from cryptostore.data.parquet import Parquet
             return Parquet(config.exchanges, config.parquet if 'parquet' in config else None, **kwargs)
         elif store == 'arctic':
+            from cryptostore.data.arctic import Arctic
             return Arctic(config.arctic)
         elif store == 'influx':
+            from cryptostore.data.influx import InfluxDB
             return InfluxDB(config.influx)
         elif store == 'elastic':
+            from cryptostore.data.elastic import ElasticSearch
             return ElasticSearch(config.elastic)
         else:
             raise ValueError("Store type not supported")


### PR DESCRIPTION
First of all, thank you, for your awesome repos!

I'm wondering if it is a good idea to use "on-demand" imports in in `cryptostore/data/storage.py`?

Motivation: I'm trying to use cryptostore with an influx backend in an alpine docker image. And if I haven't missed something, this should be possible without the pyarrow/parquet dependency (which is non trivial to install in alpine because of a missing arrow c++ package). 


### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
