### PR TITLE
Forcing type of 'size' and 'amount' as double when creating pyarrow array for parquet files.

### DIFF
--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -90,7 +90,9 @@ class Parquet(Store):
                 cols[key].append(val)
 
         to_dict = ('feed', 'symbol', 'side')
+        to_double = ('size', 'amount')
         arrays = [pa.array(cols[col], pa.string()).dictionary_encode() if col in to_dict
+                  else pa.array(cols[col], pa.float64()) if col in to_double
                   else pa.array(cols[col]) for col in cols]
         table = pa.Table.from_arrays(arrays, names=names)
         self.data = table


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [ ] - Changelog updated

When using parquet append, if by any chance, data is only int, then parquet file is created with int type for these columns.
When appending new data, if it is float, schema is then not the same.
Forcing now 'size' and 'amount' columns to be double.
