### PR TITLE
Rename kafka host kwarg to bootstrap, as cryptofeed backend expects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## Changelog
-
+  * Bugfix: rename kafka host kwarg to bootstrap, as cryptofeed backend expects
 
 ### 0.3.2
   * Bugfix: Fix book building example

--- a/cryptostore/collector.py
+++ b/cryptostore/collector.py
@@ -73,7 +73,7 @@ class Collector(Process):
                 funding_cb = FundingKafka
                 oi_cb = OpenInterestKafka
                 liq_cb = LiquidationsKafka
-                kwargs = {'host': self.config['kafka']['ip'], 'port': self.config['kafka']['port']}
+                kwargs = {'bootstrap': self.config['kafka']['ip'], 'port': self.config['kafka']['port']}
 
             if callback_type == TRADES:
                 cb[TRADES] = [trade_cb(**kwargs)]


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
Crytpofeed kafka backend's initialization expects a `bootstrap` rather than `host`. 

Currently, kafka will always default to localhost as kwarg is not passed along with the right label. 

- [x] - Tested
- [x] - Changelog updated
