### PR TITLE
Minor Bugfixes to Run Cryptostore in Docker + Redis + Parquet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir git+https://github.com/bmoscon/cryptofeed.git
 RUN pip install --no-cache-dir cython
 RUN pip install --no-cache-dir pyarrow
 RUN pip install --no-cache-dir redis
-RUN pip install --no-cache-dir aioredis
+RUN pip install --no-cache-dir git+https://github.com/aio-libs/aioredis-py@4dfdc05
 RUN pip install --no-cache-dir arctic
 RUN pip install --no-cache-dir boto3
 

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ redis:
 # must be capitalized) and only exchanges supported by cryptofeed are supported.
 # Data types follow cryptofeed definitions, see defines.py in cryptofeed for more details, common ones are
 # trades, l2_book, l3_book, funding, ticker, and open_interest
-# Trading pairs for most exchanges follow the currency-quote format. Information about what an exchange supports (pairs, data types, etc)
+# Trading symbols for most exchanges follow the currency-quote format. Information about what an exchange supports (symbols, data types, etc)
 # can be found via the info() merhod available on all cryptofeed exchange clases.
 #
 # max_depth controls the size of the book to return. The top N levels will be returned, only when those N levels
@@ -108,15 +108,15 @@ parquet:
     # Remove this parameter or set it to 0 to write a new file each 'storage_interval' (appending is then disabled).
     # Beware that a parquet file not properly closed cannot be read back. Closing is made at the last appending iteration.
     append_counter: 4
-    # File name format, as a list of arguments. Default is <exchange>-<data_type>-<pair>-<timestamp>.parquet, which would be exchange, data_type, pair, timestamp
-    # Can specify any combination exchange, data_type, pair, and timestamp
+    # File name format, as a list of arguments. Default is <exchange>-<data_type>-<symbol>-<timestamp>.parquet, which would be exchange, data_type, symbol, timestamp
+    # Can specify any combination exchange, data_type, symbol, and timestamp
     # timestamp MUST be present.
     # examples:
-    #    pair,timestamp
+    #    symbol,timestamp
     #    timestamp
     #    timestamp,exchange
     #    etc
-    file_format: [exchange, pair, data_type, timestamp]
+    file_format: [exchange, symbol, data_type, timestamp]
     # A compression codec (and level if relevant) can be defined to compress data when writing parquet file.
     # Compression is managed by use of `pyarrow.parquet.write_table()` interface.
     # Compression codecs (and levels in parentheses) are: NONE, SNAPPY, GZIP (1 to 9), BROTLI (1 to 11), LZ4 (1 is forced) & ZSTD (1 to 22).
@@ -154,7 +154,7 @@ parquet:
         # exist, it will not be created.
         service_account: null
         prefix: null
-        # Separator between `exchange`, `data_type`, and `pair` in Google Drive folder name.
+        # Separator between `exchange`, `data_type`, and `symbol` in Google Drive folder name.
         folder_name_sep: '.'
 
 # arctic specific configuration options - the mongo URL

--- a/cryptostore/data/parquet.py
+++ b/cryptostore/data/parquet.py
@@ -37,7 +37,7 @@ class Parquet(Store):
         self.buffer = parquet_buffer
         if config:
             self.file_name = config.get('file_format')
-            self.path = config.get('path')
+            self.path = config.get('path') or os.getcwd()
             self.prefix_date = config.get('prefix_date', False)
             self.del_file = config.get('del_file', True)
             # Compression
@@ -125,7 +125,6 @@ class Parquet(Store):
             local_path = os.path.join(self.path, date)
         else:
             local_path = self.path
-       
         save_path = os.path.join(self.path, "temp") if self.append_counter else local_path
 
         # Write parquet file and manage `counter`.
@@ -136,7 +135,7 @@ class Parquet(Store):
             if self.path:
                 os.makedirs(save_path, mode=0o755, exist_ok=True)
                 save_path = os.path.join(save_path, file_name)
-            
+
             writer = pq.ParquetWriter(save_path, self.data.schema, compression=self.comp_codec, compression_level=self.comp_level)
             writer.write_table(table=self.data)
             self.buffer[f_name_tips] = {'counter': 0, 'writer': writer, 'timestamp': timestamp}


### PR DESCRIPTION
### Multiple small bugfixes to run project in docker

Trying to run the project out-of-the-box with the provided Docker files results in multiple errors.
This PR aims to fix such errors and provide small changes to config file comments to align to actual code in parquet module.

1. Cryptofeed is using routines from the latest aioredis codebase, Cryptostore Dockerfile has been updated to be in sync with that.
2. Parquet module now sets `self.path` to the CWD if no input has been provided in the config file.
3. `config.yaml` use an invalid keyword for `file_format`. Parquet module expects a `symbol` keyword instead of `pair`

- [x] - Tested
- [ ] - Changelog updated
