### PR TITLE
Fix OrderBook Flattening Routines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   * Bugfix: Fix issue where max depth was being passed incorrectly to cryptofeed
   * Bugfix: rename kafka host kwarg to bootstrap, as cryptofeed backend expects
   * Feature: Candles support
+  * Bugfix: Fix l2/l3_book_flatten routines
 
 ### 0.3.1 (2020-11-14)
   * Feature: Influxdb 1.x authentication support

--- a/cryptostore/aggregator/util.py
+++ b/cryptostore/aggregator/util.py
@@ -71,14 +71,12 @@ def l3_book_flatten(data: Tuple[dict]) -> Tuple[tuple, Generator]:
          Keys of the dictionaries are also returned in a tuple to prevent having to touch the generator only for
          having this information (is used for instance for `parquet` and `artctic` backends).
     """
-
-    data = map(json.loads, [d['data'] for d in data])
     data = ({'timestamp': float(ts), 'receipt_timestamp': float(r_ts), 'delta': delta, 'side': side,
              'price': float(price), 'size': float(size), 'order_id': order_id}
             for trans in data
             for ts, r_ts, delta in ((trans['timestamp'], trans['receipt_timestamp'], trans['delta']),)
             for side in (BID, ASK)
-            for price, dat in trans[side].items()
+            for price, dat in json.loads(trans[side]).items()
             for order_id, size in dat.items())
     keys = ('timestamp', 'receipt_timestamp', 'delta', 'side', 'price', 'size', 'order_id')
     return keys, data

--- a/cryptostore/aggregator/util.py
+++ b/cryptostore/aggregator/util.py
@@ -47,14 +47,12 @@ def l2_book_flatten(data: Tuple[dict]) -> Tuple[tuple, Generator]:
          Keys of the dictionaries are also returned in a tuple to prevent having to touch the generator only for
          having this information (is used for instance for `parquet` and `artctic` backends).
     """
-
-    data = map(json.loads, [d['data'] for d in data])
     data = ({'timestamp': float(ts), 'receipt_timestamp': float(r_ts), 'delta': delta, 'side': side,
              'price': float(price), 'size': float(size)}
             for trans in data
             for ts, r_ts, delta in ((trans['timestamp'], trans['receipt_timestamp'], trans['delta']),)
             for side in (BID, ASK)
-            for price, size in trans[side].items())
+            for price, size in json.loads(trans[side]).items())
     keys = ('timestamp', 'receipt_timestamp', 'delta', 'side', 'price', 'size')
     return keys, data
 


### PR DESCRIPTION
This PR fixes a small issue in handling L2/L3 flattening routines used by the Redis aggregator. 
Implementation now matches input data layout and JSON de-serialisation is performed successfully.

Changes have been tested with the following configuration and Parquet storage:
```yaml
BITMEX:
    channel_timeouts:
        l2_book: 30
    l2_book:
        symbols: [BTC-USD]
        max_depth: 50
        book_delta: true
        book_interval: 100000
COINBASE:
    channel_timeouts:
        l3_book: 30
    l3_book:
        symbols: [BTC-USD]
        book_delta: true
        book_interval: 100000
BINANCE:
    channel_timeouts:
        l2_book: 30
    l2_book:
        symbols: [BTC-USDT]
        max_depth: 50
        book_delta: true
        book_interval: 100000
```

Example L2 OrderBook Parquet file:
|     |    timestamp|  receipt_timestamp| delta| side|    price|       size|
|:----|------------:|------------------:|-----:|----:|--------:|----------:|
|0    | 1.617005e+09|       1.617005e+09|  True|  bid|  56006.5|  2419553.0|
|1    | 1.617005e+09|       1.617005e+09|  True|  bid|  56006.5|  2430130.0|
|2    | 1.617005e+09|       1.617005e+09|  True|  bid|  56006.5|  2440356.0|
|3    | 1.617005e+09|       1.617005e+09|  True|  bid|  56005.0|        0.0|
|4    | 1.617005e+09|       1.617005e+09|  True|  bid|  55957.0|   453813.0|
|...  |          ...|                ...|   ...|  ...|      ...|        ...|
|3225 | 1.617005e+09|       1.617005e+09|  True|  ask|  56048.5|     3095.0|
|3226 | 1.617005e+09|       1.617005e+09|  True|  bid|  56017.5|        0.0|
|3227 | 1.617005e+09|       1.617005e+09|  True|  bid|  55987.0|    53439.0|
|3228 | 1.617005e+09|       1.617005e+09|  True|  ask|  56086.0|    12000.0|
|3229 | 1.617005e+09|       1.617005e+09|  True|  ask|  56089.0|       12.0|


Example L3 OrderBook Parquet file:
|      |    timestamp|  receipt_timestamp|  delta| side|     price|      size|                              order_id|
|:-----|------------:|------------------:|------:|----:|---------:|---------:|-------------------------------------:|
|0     | 1.617006e+09|       1.617006e+09|   True|  bid|  56181.55|  0.459500|  3507e4df-a79e-4014-9557-dde827ad92b5|
|1     | 1.617006e+09|       1.617006e+09|  False|  bid|  56235.93|  0.050000|  7c45ff78-fae5-4953-b7ed-11ad63c6ebbc|
|2     | 1.617006e+09|       1.617006e+09|  False|  bid|  56235.93|  0.009858|  aeea14a1-ea02-4263-834f-a617c75232f0|
|3     | 1.617006e+09|       1.617006e+09|  False|  bid|  56235.93|  0.062251|  78930526-bbf4-47d0-8db4-e24e5c196b1f|
|4     | 1.617006e+09|       1.617006e+09|  False|  bid|  56235.93|  0.050000|  cfc82d0d-7abc-449c-b857-c282b78e6f37|
|...   |          ...|                ...|    ...|  ...|       ...|       ...|                                   ...|
|94485 | 1.617006e+09|       1.617006e+09|   True|  bid|  56161.39|  0.100000|  95c004ef-ba21-4ac1-8346-a4131671a7b2|
|94486 | 1.617006e+09|       1.617006e+09|   True|  ask|  56255.62|  0.000000|  f01111d9-35cc-4535-81e4-0dba6cf8e29a|
|94487 | 1.617006e+09|       1.617006e+09|   True|  bid|  56230.63|  0.003661|  a75a465c-b8b1-4116-84ef-a0f9aee512bd|
|94488 | 1.617006e+09|       1.617006e+09|   True|  bid|  56230.63|  0.000000|  a75a465c-b8b1-4116-84ef-a0f9aee512bd|
|94489 | 1.617006e+09|       1.617006e+09|   True|  ask|  56435.51|  0.000000|  945a6841-89cf-441c-ae68-2f58121c91d3|

- [x] - Tested (Redis only)
- [x] - Changelog updated
