### PR TITLE
Add support for storing raw data files

### DIFF
--- a/cryptostore.py
+++ b/cryptostore.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import os
 
 from cryptofeed import FeedHandler
+from cryptofeed.raw_data_collection import AsyncFileCallback
 from cryptofeed.exchanges import EXCHANGE_MAP
 from cryptofeed.feed import Feed
 from cryptofeed.defines import L2_BOOK, TICKER, TRADES, FUNDING, CANDLES, OPEN_INTEREST, LIQUIDATIONS
@@ -151,7 +152,16 @@ def load_config() -> Feed:
 
 
 def main():
-    fh = FeedHandler()
+    save_raw = os.environ.get('SAVE_RAW', False)
+    if save_raw:
+        if save_raw.lower().startswith('f'):
+            save_raw = False
+        elif save_raw.lower().startswith('t'):
+            save_raw = True
+        else:
+            raise ValueError('Invalid value specified for SAVE_RAW')
+        
+    fh = FeedHandler(raw_data_collection=AsyncFileCallback("./raw_data") if save_raw else None)
     cfg = load_config()
     fh.add_feed(cfg)
     fh.run()

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,6 +20,7 @@ Cryptostore runs in a docker container, and expects configuration to be provided
 * CHANNELS - cryptofeed data channels (trades, l2book, ticker, etc.) Can be a single channel or a list of channels.
 * CONFIG - path to cryptofeed config file (must be built into the container or otherwise accessible in the container). Not required. 
 * BACKEND - Backend to be used, see list of supported backends above.
+* SAVE_RAW - Keep raw data and save it to file. Default is False, and even when True you still have to specify a backend for the processed data. To persist the raw data files you should bind the /raw_data folder in the container to a local volume. E.g. add `-v /your/local/path:/raw_data` to your `docker run` command.
 * SNAPSHOT_ONLY - Valid for orderbook channel only, specifies that only complete books should be stored. Default is False.
 * SNAPSHOT_INTERVAL - Specifies how often snapshot is stored in terms of number of delta updates between snapshots. Default is 1000.
 * HOST - Host for backend. Defaults to localhost. TCP, UDP and UDS require the protocol to be prepended to the host/url. E.g. `tcp://127.0.0.1`, `uds://udsfile.tmp`, etc.


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
This PR allows storing to file the raw data received from the exchanges by setting the `SAVE_RAW` environment variable, in addition to the standard behavior of sending the processed data to the desired backend.

The documentation has been updated to reflect this addition, with detailed instructions for the new environment variable and its usage.
